### PR TITLE
New peer nodes for Feathercoin  (#917)

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1950,7 +1950,9 @@ class Feathercoin(Coin):
     RPC_PORT = 9337
     REORG_LIMIT = 2000
     PEERS = [
-        'electrumx-ch-1.feathercoin.ch s t',
+        'electrumx-gb-1.feathercoin.network s t',
+        'electrumx-gb-2.feathercoin.network s t',
+        'electrumx-de-1.feathercoin.network s t',
     ]
 
 


### PR DESCRIPTION
* Change of hard coded peer servers for Feathercoin

The domain of the peer server hard coded in coins.py for Feathercoin has expired.
Two new peers added.